### PR TITLE
replace eval() by variable function call

### DIFF
--- a/matheval.class.php
+++ b/matheval.class.php
@@ -327,7 +327,7 @@ class EvalMath {
                     if (is_null($op1 = $stack->pop())) return $this->trigger("internal error");
                     $fnn = preg_replace("/^arc/", "a", $fnn); // for the 'arc' trig synonyms
                     if ($fnn == 'ln') $fnn = 'log';
-                    eval('$stack->push(' . $fnn . '($op1));'); // perfectly safe eval()
+                    $stack->push($fnn($op1)); // perfectly safe variable function call
                 } elseif (array_key_exists($fnn, $this->f)) { // user function
                     // get args
                     $args = array();


### PR DESCRIPTION
avoid eval() whenever possible. This allows to use MathEval in HHVM RepoAuthoritative Mode, where no dynamic code generation is allowed.
